### PR TITLE
Center the position of plus and minus symbols on buttons

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -179,7 +179,9 @@ function scene:create(event)
 		strokeColor = {default = uiColorGreenLight, over = uiColorGreenMedium},
 		strokeWidth = 12,
 		labelColor = {default = uiColorLight, over = uiColorDark},
-		fontSize = 160
+		fontSize = 160,
+		font = "Tahoma",
+		labelYOffset = -11
 	})
 	
 	uiGroup:insert(plusButton)
@@ -200,7 +202,9 @@ function scene:create(event)
 		strokeColor = {default = uiColorGreenLight, over = uiColorGreenMedium},
 		strokeWidth = 12,
 		labelColor = {default = uiColorLight, over = uiColorDark},
-		fontSize = 160
+		fontSize = 160,
+		font = "Tahoma",
+		labelYOffset = -11
 	})
 	
 	uiGroup:insert(minusButton)


### PR DESCRIPTION
Centers the vertical position of plus and minus symbols on buttons. Changes their font to «Tahoma».

Closes #35